### PR TITLE
fix: Remove Firebase rewrite rule that breaks Quartz notes routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,6 @@
 public/
 resources/_gen/
 
-# Quartz-built notes (deployed separately from notes repo)
-# Notes are built in the private notes repository and copied here
-public/notes/
-
 # Temporary files
 .DS_Store
 .vscode/

--- a/firebase.json
+++ b/firebase.json
@@ -8,12 +8,6 @@
     ],
     "cleanUrls": true,
     "trailingSlash": false,
-    "rewrites": [
-      {
-        "source": "/notes/**",
-        "destination": "/notes/index.html"
-      }
-    ],
     "headers": [
       {
         "source": "**/*.@(jpg|jpeg|gif|png|svg|webp|ico)",


### PR DESCRIPTION
The rewrite rule was redirecting ALL /notes/** paths to /notes/index.html, which prevented individual Quartz note pages from loading correctly.

Changes:
- Removed problematic rewrite rule from firebase.json
- Cleaned up redundant public/notes/ entry in .gitignore
- Quartz notes in static/notes/ will now be correctly served via Hugo build

This fix ensures that:
1. Hugo copies static/notes/ -> public/notes/ during build
2. Firebase serves all Quartz pages correctly without rewrites
3. Individual note pages are accessible at their proper URLs