### PR TITLE
refactor: Simplify portfolio content for better readability

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,41 +13,27 @@ I'm a software engineer based in Paris, with roots in Vietnam and a background i
 
 ## My Journey: From Ocean Science to Code
 
-My path into technology didn't start with a computer, but with the ocean. As a scientist student at Aix-Marseille University and later at LSCE-CEA, I specialized in physical and chemical oceanography, especially in modeling the distribution of mercury in marine ecosystems. I used complex climate datasets and mathematical models to understand large-scale systems and climate change evolution.
+My path into technology started with computational oceanography at Aix-Marseille University and LSCE-CEA, where I modeled mercury distribution in marine ecosystems using complex climate datasets. That work sparked my curiosity for building the tools themselves, leading me to software engineering.
 
-That's where I had my "aha" moment. I realized I always liked to take classes that use programming and wanted to build the tools myself. It was this curiosity for the underlying mechanics that led me to software engineering.
-
-I found my place at **42 Paris**, an intense, lecture-free learning environment where the only way to learn is to build, break, and collaborate. It was there that I got to dive deep into C/C++ systems programming, algorithms, and fundamental problem-solving by building projects like network servers, graphics engines, and containerized web services from the ground up.
-
-Today, I continue that journey as an engineer. Every project is a new opportunity to understand a complex system, whether it's by optimizing a graphical render, securing a web application, or writing C++ code to protect user data.
+At **42 Paris**, I dove deep into C/C++ systems programming through hands-on projects—network servers, graphics engines, and containerized services. Today, I apply that same systems-thinking approach to solve technical challenges, whether optimizing performance, securing applications, or building robust infrastructure.
 
 ---
 
 ## Experience
 
 ### **C++ Development Engineer at Snowpack**
-
 *August 2024 – July 2025*
 
-> [Snowpack](https://snowpack.eu/) develops an innovative solution to protect user data with a VIPN (Virtual & Invisible Private Network), transforming data into "snowflakes" to make users invisible online.
+> [Snowpack](https://snowpack.eu/) develops privacy-focused VPN solutions to protect user data online.
 
-**Missions:**
-
-* Led the effort to port Snowpack's C++ SDK to run in browsers using **WebAssembly (Wasm)**, successfully creating a proof-of-concept that validated cross-platform feature deployment.
-* Ensured software quality by developing test suites and performing rigorous testing across diverse platforms (Android, macOS, ARM64), identifying critical bugs to accelerate their resolution.
-* Improved the command-line tool's usability and security by implementing features like robust MFA handling, service listing, and a memory-safe log rotation strategy.
-* Collaborated with cross-functional teams to develop and specify user data consumption tracking (without knowing the user data's content of course) features across C++, Android, and iOS applications.
+Ported C++ SDK to browsers using **WebAssembly**, developed cross-platform test suites (Android, macOS, ARM64), and implemented security features including MFA handling and memory-safe log rotation. Collaborated on data consumption tracking across C++, Android, and iOS platforms.
 
 ### **Research Intern at LSCE-CNRS**
-
 *February 2021 – August 2021*
 
-> The LSCE is a leading research laboratory focused on climate and environmental sciences.
+> Leading climate and environmental sciences research laboratory.
 
-**Missions:**
-
-* Contributed to global climate research by developing and adding new modules in FORTRAN to IPCC-class climate models, used to analyze mercury distribution in marine ecosystems.
-* Processed very large datasets using Python, an experience that taught me the critical importance of clean code and reproducible results in scientific research.
+Developed FORTRAN modules for IPCC-class climate models to analyze mercury distribution in marine ecosystems. Processed large-scale climate datasets using Python, emphasizing clean code and reproducibility.
 
 ---
 
@@ -82,13 +68,7 @@ Today, I continue that journey as an engineer. Every project is a new opportunit
 
 ## Other Interests
 
-### **CTF Competitions**
-
-I participate in CTFs to learn applied security concepts in a hands-on way. It's a practical method for understanding web security, cryptography, and binary exploitation. I maintain a repository of my writeups [here](https://github.com/tham-le/CTF-Writeups).
-
-### **Hackathons**
-
-I enjoy participating in hackathons to rapidly build solutions for real-world problems. I've worked on projects related to health tech (DigHacktion) and women's health (InnovHer), and participated in hardware-focused events like the Google Hardware Hackathon.
+I participate in **CTF competitions** to learn applied security concepts hands-on, covering web security, cryptography, and binary exploitation. I maintain writeups [here](https://github.com/tham-le/CTF-Writeups). I also enjoy **hackathons** for rapid prototyping, having worked on health tech projects (DigHacktion, InnovHer) and hardware challenges (Google Hardware Hackathon).
 
 ---
 

--- a/content/projects/Python-for-Data-Science.md
+++ b/content/projects/Python-for-Data-Science.md
@@ -23,85 +23,30 @@ stats:
     language: Python
 ---
 
-# Piscine python for data science
+# Python for Data Science
 
-This repository contains a series of Python projects organized into modules, designed to progressively build data science skills.  It follows a "piscine" style of learning, where each module focuses on a particular aspect of Python and its application to data science.
+A comprehensive series of Python projects following a "piscine" learning approach, progressively building data science fundamentals through hands-on exercises.
 
-## Modules Overview
+## Modules
 
-### Python-0-Starting: Introduction to Python Basics
+### Module 0: Python Basics
+Core Python concepts including data structures, string manipulation, type handling, command-line arguments, custom packages, and error handling. Includes a custom progress bar implementation and Morse code encoder.
 
-This module covers the fundamentals of Python programming:
+### Module 1: Arrays & Image Processing
+NumPy arrays and image manipulation with matplotlib. Covers BMI calculations, 2D array operations, image loading, grayscale conversion, zooming, rotation, and color channel manipulation.
 
-*   **ex00/Hello.py:** Introduces basic Python data structures (lists, tuples, sets, dictionaries) and their mutability.
-*   **ex01/format_ft_time.py:** Demonstrates how to work with time, including formatting and scientific notation.
-*   **ex02/find_ft_type.py:** Shows how to determine the type of a Python object.
-*   **ex03/NULL_not_found.py:**  Explores handling of NULL values and other special data types (NaN, empty strings, False, 0).
-*   **ex04/whatis.py:**  Uses command-line arguments (`sys.argv`) and exception handling to determine if a number is even or odd.
-*   **ex05/building.py:**  Performs string manipulation to count characters (uppercase, lowercase, punctuation, spaces, digits).  Handles user input and potential errors (EOFError).
-*   **ex06/filterstring.py:** Filters words in a string based on length, using a custom `ft_filter` function and lambda expressions.
-*   **ex06/ft_filter.py:**  Implements a custom filter function, mimicking the built-in `filter` function.
-*   **ex07/sos.py:** Encodes a string into Morse code using a dictionary.
-*   **ex08/Loading.py:** Creates a custom progress bar (`ft_tqdm`) using `sys.stdout.write` and `os.get_terminal_size`.
-*   **ex09/usage.py:** Demonstrates the usage of the `ft_package`.
-*   **ex09/ft_package/:**  Contains a simple Python package with a single function (`count_in_list`) to count the occurrences of an item in a list. Includes `pyproject.toml` for building the package.
+### Module 2: Data Tables
+Data analysis with pandas: loading CSV files, visualizing life expectancy trends, population data, and exploring correlations between GDP and life expectancy with scatter plots.
 
-### Python-1-Array: Working with Arrays and Image Manipulation
+### Module 3: Object-Oriented Programming
+OOP concepts including abstract base classes, inheritance, multiple inheritance (diamond problem), class methods, dunder methods, static methods, getters/setters.
 
-This module focuses on using NumPy arrays and basic image processing with `matplotlib`:
+### Module 4: Data-Oriented Design
+Advanced Python patterns: statistical functions (mean, median, quartile, std dev, variance), closures, decorators, and dataclasses with automatic field generation.
 
-*   **ex00/give_bmi.py:** Calculates BMI from lists of height and weight, with error handling.  Includes a function to apply a limit and return a boolean array.
-*   **ex01/array2D.py:** Slices a 2D array (represented as a list of lists) and prints its shape, mimicking NumPy array slicing.
-*   **ex02/load_image.py:** Loads an image using `matplotlib.image` and prints its shape.  Basic error handling.
-*   **ex03/load_image.py:**  Loads an image with improved error handling (raising exceptions).
-*   **ex03/zoom.py:** Loads an image, zooms into the center, converts it to grayscale, and displays the results using `matplotlib.pyplot`.
-*   **ex04/load_image.py:** Same as ex03/load_image.py.
-*   **ex04/rotate.py:** Loads an image, cuts out a square, converts it to grayscale, rotates it by 90 and -90 degrees (implemented manually), and displays the results.
-*   **ex05/load_image.py:**  Same as ex03/load_image.py.
-*   **ex05/pimp_image.py:**  Provides functions to manipulate images: invert colors, isolate red/green/blue channels, and convert to grayscale.
+## Technologies
 
-### Python-2-DataTable: Data Loading, Manipulation, and Visualization
+**Libraries**: NumPy, pandas, matplotlib
+**Concepts**: Data structures, image processing, data visualization, OOP, functional programming, decorators
 
-This module uses the `pandas` library to work with tabular data:
-
-*   **income_per_person_gdppercapita_ppp_inflation_adjusted.csv:**  CSV file containing GDP per capita data.
-*   **life_expectancy_years.csv:** CSV file containing life expectancy data.
-*   **population_total.csv:** CSV file containing population data.
-*   **ex00/load_csv.py:** A function to load a CSV file into a pandas DataFrame, with error handling.
-*   **ex01/aff_life.py:** Loads life expectancy data and plots the projection for France.
-*   **ex01/load_csv.py:**  Same as ex00/load_csv.py.
-*   **ex02/aff_pop.py:**  Loads population data and plots the population of France and Belgium, with custom formatting for the y-axis.
-*   **ex02/load_csv.py:** Same as ex00/load_csv.py.
-*   **ex03/load_csv.py:** A slightly modified version of ex00/load_csv.py, raising exceptions instead of printing errors.
-*   **ex03/projection_life.py:**  Loads life expectancy and GDP data, and creates a scatter plot showing the relationship between the two for the year 1900.
-
-### Python-3-OOP: Object-Oriented Programming
-
-This module introduces object-oriented programming concepts in Python:
-
-*   **ex00/S1E9.py:** Defines an abstract base class `Character` with an abstract method `die()`, and a concrete class `Stark` inheriting from it.
-*   **ex00/tester.py:** Tests the `Character` and `Stark` classes.
-*   **ex01/S1E7.py:** Defines `Baratheon` and `Lannister` classes, inheriting from `Character`, with specific attributes and a `create_lannister` class method.
-*   **ex01/S1E9.py:** Same as ex00/S1E9.py.
-*   **ex01/tester.py:** Tests the `Baratheon` and `Lannister` classes.
-*   **ex02/DiamondTrap.py:** Defines a `King` class that inherits from both `Baratheon` and `Lannister`, demonstrating multiple inheritance. Includes getter and setter methods.
-*   **ex02/S1E7.py:**  Slightly modified versions of the `Baratheon` and `Lannister` classes.
-*   **ex02/S1E9.py:** Same as ex00/S1E9.py.
-*   **ex02/tester.py:**  Tests the `King` class.
-*   **ex03/ft_calculator.py:** Implements a `calculator` class that performs element-wise operations (+, -, \*, /) on a list (acting like a vector) with a scalar. Uses dunder methods (`__add__`, `__mul__`, `__sub__`, `__truediv__`).
-*   **ex03/tester.py:** Tests the `calculator` class.
-*   **ex04/ft_calculator.py:**  Implements a `calculator` class with static methods to perform dot product, vector addition, and vector subtraction.
-*   **ex04/tester.py:** Tests the `calculator` class.
-
-### Python-4-DOD: Data-Oriented Design
-
-This module explores data-oriented design principles:
-
-*   **ex00/statistics.py:**  Defines a function `ft_statistics` that calculates mean, median, quartile, standard deviation, and variance of a variable number of numerical arguments. Uses keyword arguments to specify which statistics to calculate.
-*   **ex00/tester.py:** Tests the `ft_statistics` function.
-*   **ex01/in_out.py:**  Demonstrates nested functions and closures.  The `outer` function returns an inner function that maintains a count and applies a given function to it repeatedly.
-*   **ex01/tester.py:**  Tests the `outer` function with `square` and `pow`.
-*   **ex02/callLimit.py:**  Creates a decorator `callLimit` that limits the number of times a function can be called.
-*   **ex02/tester.py:** Tests the `callLimit` decorator.
-*   **ex03/new_student.py:**  Defines a `Student` dataclass with fields for name, surname, active status, login, and a randomly generated ID. The login is automatically generated in `__post_init__`.
-*   **ex03/tester.py:** Tests the `Student` dataclass.
+*Detailed exercises and implementations available in the [GitHub repository](https://github.com/tham-le/Python-for-Data-Science).*

--- a/content/projects/fractol.md
+++ b/content/projects/fractol.md
@@ -39,87 +39,33 @@ stats:
 
 # Fractol - Advanced Fractal Explorer
 
-**High-performance fractal visualization in C with multi-threading and advanced graphics**
+High-performance fractal visualization in C with multi-threading and interactive graphics. Extends the 42 School assignment with advanced features demonstrating systems programming and optimization.
 
-> **Note:** This project extends the original 42 School fract-ol assignment with advanced features demonstrating systems programming, optimization, and graphics expertise. Please enjoy peer-learning at 42 - don't copy.
+## Features
 
-## Technical Achievements
+- **8 Fractal Types**: Mandelbrot, Julia, Burning Ship, Newton, Tricorn, Barnsley Fern, Mandelbar, Multibrot
+- **Multi-Threading**: Automatic CPU core detection with 2-8x rendering speed improvements
+- **13 Color Palettes**: Real-time switching with smooth interpolation
+- **Interactive Controls**: Mouse pan/zoom, real-time parameter modification
+- **Export**: BMP/PPM image and animation export
+- **Anti-Aliasing**: Adaptive supersampling for quality rendering
 
-**Core Technologies:** C, MinilibX, POSIX threads, Computer Graphics
-**Performance:** Multi-threaded rendering with 2-8x speed improvements
-**Export Formats:** BMP, PPM with animation support
-
-## Visual Showcase
-
-**High-quality fractal renders demonstrating mathematical precision and artistic beauty:**
-
-<div align="center">
-
-### Mandelbrot Set - Color Variations
-<img src="image/mandelbrot-smooth-color.bmp" width="300" alt="Mandelbrot Smooth Colors"/> <img src="image/mandelbrot-fire.bmp" width="300" alt="Mandelbrot Fire Palette"/>
-
-### Newton Fractal - Advanced Mathematics
-<img src="image/Newton.bmp" width="300" alt="Newton Fractal"/> <img src="image/Newton-rainbow.bmp" width="300" alt="Newton Rainbow"/>
-
-### Julia Set Collection - Parameter Exploration
-<img src="image/julia-1.bmp" width="200" alt="Julia Set 1"/> <img src="image/julia_2.bmp" width="200" alt="Julia Set 2"/> <img src="image/julia_3.bmp" width="200" alt="Julia Set 3"/> <img src="image/julia_6.bmp" width="200" alt="Julia Set 6"/>
-
-### Barnsley Fern - Nature-Inspired Fractals
-<img src="image/barnley.bmp" width="400" alt="Barnsley Fern"/>
-
-</div>
-
-*All images rendered in real-time with multi-threaded optimization*
-
-### Key Features Beyond Original Assignment
-- **Multi-threaded rendering** - Automatic CPU core detection and workload distribution
-- **8 fractal types** - Mandelbrot, Julia, Burning Ship, Newton, Tricorn, Barnsley Fern, Mandelbar, Multibrot
-- **13 optimized color palettes** - Real-time switching with smooth interpolation
-- **Advanced interactions** - Mouse panning, scroll zoom, parameter modification
-- **Export capabilities** - Image and animation export with timestamp management
-- **Configuration system** - Save/load views and settings
-- **Anti-aliasing** - Adaptive supersampling for quality rendering
-
-## Installation & Usage
+## Usage
 
 ```bash
-# Clone and build
 git clone --recursive https://github.com/tham-le/fractol.git
-cd fractol
-make
+cd fractol && make
 
-# Run examples
 ./fractol mandelbrot
 ./fractol julia 0.285 0.01
 ./fractol help
 ```
 
-## Technical Implementation
+## Technical Stack
 
-**Performance Optimizations:**
-- Multi-threading with POSIX threads for parallel computation
-- Efficient memory management and minimal overhead
-- Adaptive algorithms based on fractal complexity
+- **Language**: C with MinilibX graphics library
+- **Concurrency**: POSIX threads for parallel computation
+- **Mathematics**: Complex number operations, iterative algorithms
+- **Optimization**: Efficient memory management, adaptive algorithms
 
-**Advanced Features:**
-- Real-time parameter modification and smooth transitions
-- Professional-grade color interpolation algorithms
-- Cross-platform compatibility and robust error handling
-
-**Interactive Controls:**
-- Mouse-based navigation (drag to pan, scroll to zoom)
-- Keyboard shortcuts for all features
-- Real-time performance toggling and comparison
-
-
-## Project Evolution
-
-Started as a 42 School assignment and evolved into a comprehensive fractal explorer showcasing:
-- Advanced C programming techniques
-- Multi-threaded application development
-- Graphics programming and mathematical computation
-- Software engineering best practices
-
----
-
-**A demonstration of technical growth and practical application of computer science fundamentals.**
+*Gallery of fractal renders showcasing mathematical precision and artistic beauty available in the [GitHub repository](https://github.com/tham-le/fractol).*

--- a/content/projects/ft_irc.md
+++ b/content/projects/ft_irc.md
@@ -26,100 +26,35 @@ stats:
 
 # ft_irc
 
-This project is an implementation of a basic IRC server, adhering to a subset of the IRC RFC specifications (primarily RFC 2810, 2811, 2812, 2813, and 7194). It's part of the 42 School curriculum, designed to teach network programming, concurrent handling, and server-side development.
+A C++ implementation of an IRC (Internet Relay Chat) server following RFC specifications (2810-2813, 7194). This project demonstrates network programming, concurrent connection handling, and server-side development using sockets and the `poll()` system call.
 
 ## Features
 
-*   **Basic Connection Handling:** Accepts and manages client connections using `socket`, `bind`, `listen`, `accept`, and `poll`.
-*   **User Authentication:** Requires a server password for initial connection and supports `NICK` and `USER` commands for registration.
-*   **Channel Management:**
-    *   Creation and joining of channels (`JOIN`).
-    *   Listing available channels (`LIST`).
-    *   Leaving channels (`PART`).
-    *   Sending messages to channels (`PRIVMSG`).
-    *   Channel topics (`TOPIC`).
-    *   Channel modes (invite-only, key, user limit, topic-setting restrictions).
-*   **Message Handling:**
-    *   Sending private messages to other users (`PRIVMSG`).
-    *   Basic command parsing and execution.
-*   **Operator Privileges:**  Channel operators can kick users (`KICK`), invite users (`INVITE`) and change channel modes (`MODE`).
-*   **Information Commands:**
-    *   `WHOIS`:  Retrieves information about a specific user.
-    *   `INFO`: Displays server information.
-    *   `ADMIN`: Displays administrative information about the server.
-    *   `VERSION`: Displays server version.
-*   **Utility Commands:**
-    *   `PING`/`PONG`:  Keeps the connection alive.
-    *   `QUIT`: Disconnects the client.
-    *   `NAMES`:  Lists users in a channel.
-*   **Logging:** Logs server activity to a file.
-*   **Error Handling:** Implements several error replies as defined in the IRC specifications.
-
-## Compilation
-
-To compile the project, use the following command:
-
-```bash
-make
-```
-
-This will create an executable file named `ircserv` in the main directory.
+- **Connection Management**: Multi-client handling with socket programming (`bind`, `listen`, `accept`, `poll`)
+- **Authentication**: Password-protected server with user registration (`NICK`, `USER`)
+- **Channels**: Create, join, manage channels with topics, modes (invite-only, key, user limits)
+- **Messaging**: Private messages and channel communication
+- **Operator Tools**: Kick, invite, and mode management
+- **Utilities**: WHOIS, INFO, ADMIN, VERSION, PING/PONG, server logging
 
 ## Usage
 
-To run the IRC server, use the following command:
-
 ```bash
-./ircserv <port> <password>
+make                           # Compile the project
+./ircserv <port> <password>   # Run the server
 ```
 
-*   `<port>`:  The port number the server will listen on.
-*   `<password>`: The server password required for clients to connect.
+Example: `./ircserv 6667 mysecretpassword`
 
-Example:
+## Architecture
 
-```bash
-./ircserv 6667 mysecretpassword
-```
+Built with C++98, the server uses an event-driven architecture with `poll()` for handling multiple simultaneous client connections. Core classes include:
+- **Ircserv**: Main server managing connections and event loop
+- **User**: Client representation with authentication state
+- **Channel**: Channel management with modes and permissions
+- **Command**: Command parser and executor
 
-## Classes Description
-
-*   **`Ircserv`**: Represents the IRC server itself. Manages client connections, channels, and the main event loop.
-*   **`User`**: Represents a connected client. Stores user information (nickname, username, realname, etc.) and manages communication with the client.
-*   **`Channel`**: Represents an IRC channel. Stores channel information (name, topic, mode, etc.) and manages users within the channel.
-*   **`Command`**: Base class for handling IRC commands. Parses commands and calls the appropriate function.
-*   **`Config`**: Holds the server configuration parameters (port, password, etc.).
-
-## Implemented Commands
-
-The following IRC commands are implemented:
-
-*   `PASS`: Sets the connection password.
-*   `NICK`: Sets the user's nickname.
-*   `USER`: Sets the user's username, hostname, and realname.
-*   `JOIN`: Joins a channel.
-*   `PART`: Leaves a channel.
-*   `PRIVMSG`: Sends a private message to a user or channel.
-*   `PING`: Sends a ping to the server.
-*   `PONG`: Responds to a ping from the server.
-*   `QUIT`: Disconnects from the server.
-*   `LIST`: Lists available channels.
-*   `NAMES`: Lists users in a channel.
-*   `WHOIS`: Retrieves information about a user.
-*   `ADMIN`: Retrieves information about the server administrator.
-*   `INFO`: Retrieves server information.
-*   `VERSION`: Retrieves server version information.
-*   `KICK`: Kicks a user from a channel.
-*   `INVITE`: Invites a user to a channel.
-*   `TOPIC`: Sets or displays the channel topic.
-*   `MODE`: Sets or displays channel modes.
-*   `CAP`: Capability negotiation (minimal support).
-
-## Notes
-
-*   This project is a simplified implementation of an IRC server and does not implement the full IRC specification.
-*   Error handling is limited.
-*   The project adheres to the C++98 standard.
+Implements 20+ IRC commands including PASS, NICK, USER, JOIN, PART, PRIVMSG, KICK, INVITE, MODE, TOPIC, and more.
 
 ## Authors
 

--- a/content/projects/inception.md
+++ b/content/projects/inception.md
@@ -27,119 +27,28 @@ stats:
 
 # Inception - Docker-based Web Infrastructure
 
-This project demonstrates a sophisticated web infrastructure setup using Docker containers, showcasing system administration and containerization skills. The infrastructure runs a WordPress site with MariaDB database, Redis caching, and Nginx as a reverse proxy, all orchestrated using Docker Compose.
+A multi-container web infrastructure project demonstrating Docker orchestration and system administration. The setup runs WordPress with MariaDB, Redis caching, and Nginx as a reverse proxy—all containerized and deployed on an Alpine Linux VM, creating nested layers of virtualization (VM → Containers → Services).
 
-## 🎬 Why "Inception"?
+## Key Features
 
-The name "Inception" is inspired by the concept of "a dream within a dream" from Christopher Nolan's movie. In this project, we create multiple layers of virtualization:
+- **Services**: Nginx with SSL, WordPress, MariaDB, Redis
+- **Security**: SSL/TLS encryption, environment variables, persistent volumes
+- **Best Practices**: Custom Dockerfiles, volume management, container networking, health checks
 
-1. **First Layer**: A Linux Alpine virtual machine
-2. **Second Layer**: Docker containers running inside the VM
-3. **Third Layer**: Services (WordPress, MariaDB, etc.) running inside the containers
+## Usage
 
-This nested virtualization approach demonstrates advanced system administration concepts and containerization techniques, making it a perfect example of "infrastructure within infrastructure" - hence the name "Inception".
-
-## 🚀 Features
-
-- **Containerized Services**:
-  - Nginx web server with SSL support
-  - WordPress CMS
-  - MariaDB database
-  - Redis caching system
-- **Secure Configuration**:
-  - SSL/TLS encryption
-  - Environment variable management
-  - Persistent data storage
-- **Docker Best Practices**:
-  - Custom Dockerfile configurations
-  - Volume management for data persistence
-  - Container networking
-  - Health checks and automatic restarts
-
-## 🛠️ Prerequisites
-
-- Docker and Docker Compose
-- SSH access to a Linux Alpine VM
-- Basic understanding of containerization concepts
-
-## 🏗️ Architecture
-
-The project consists of four main services:
-
-1. **Nginx**: Acts as a reverse proxy, handling SSL termination and serving static content
-2. **WordPress**: The CMS running the website
-3. **MariaDB**: Database server for WordPress
-4. **Redis**: Caching system to improve performance
-
-## 🚀 Getting Started
-
-1. Clone the repository:
-
-   ```bash
-   git clone <repository-url>
-   cd inception
-   ```
-
-2. Start the services:
-
-   ```bash
-   make up
-   ```
-
-3. Access the website at `https://localhost`
-
-## 🛠️ Available Commands
-
-- `make up`: Start all containers
-- `make down`: Stop all containers
-- `make re`: Restart all containers
-- `make fclean`: Remove all containers, images, and volumes (with confirmation)
-
-## 🔧 Configuration
-
-The project uses environment variables for sensitive configuration. Create a `.env` file in the `srcs` directory with the following variables:
-
-```
-MYSQL_ROOT_PASSWORD=your_root_password
-MYSQL_DATABASE=wordpress
-MYSQL_USER=wordpress_user
-MYSQL_PASSWORD=wordpress_password
+```bash
+make up      # Start all containers
+make down    # Stop containers
+make re      # Restart containers
+make fclean  # Remove all containers, images, and volumes
 ```
 
-## 📁 Project Structure
+Configuration uses environment variables in `srcs/.env` for database credentials and settings.
 
-```
-inception/
-├── srcs/
-│   ├── docker-compose.yml
-│   ├── requirements/
-│   │   ├── nginx/
-│   │   ├── wordpress/
-│   │   ├── mariadb/
-│   │   └── redis/
-│   └── .env
-├── Makefile
-└── README.md
-```
+## Technologies
 
-## 🔒 Security Considerations
+**Stack**: Docker, Docker Compose, Nginx, WordPress, MariaDB, Redis
+**Concepts**: Multi-container orchestration, SSL/TLS, persistent volumes, container networking
 
-- All services run in isolated containers
-- SSL/TLS encryption for secure communication
-- Environment variables for sensitive data
-- Persistent volumes for data storage
-
-## 🎯 Learning Outcomes
-
-This project demonstrates:
-
-- Docker containerization
-- Multi-container application orchestration
-- Web server configuration
-- Database management
-- Caching implementation
-- System administration skills
-
-## 📝 License
-
-This project is part of the 42 school curriculum.
+*Part of the 42 school curriculum. Full details and setup instructions available in the [GitHub repository](https://github.com/tham-le/inception).*

--- a/content/projects/mindful.md
+++ b/content/projects/mindful.md
@@ -30,106 +30,32 @@ stats:
 
 # MindfulWealth
 
-MindfulWealth is a financial assistant application designed to help users make mindful spending decisions and encourage saving and investing.
+An AI-powered financial assistant that helps users make mindful spending decisions and encourages saving and investing. Built with Flask, React, and Google's Gemini AI.
 
 ## Features
 
-- **AI-Powered Chat**: Interact with an AI financial assistant that helps you make better spending decisions
-- **Impulse Purchase Analysis**: Get insights on potential impulse purchases and their long-term financial impact
-- **Investment Projections**: See how your money could grow if invested instead of spent
-- **Multiple Personality Modes**: Choose between different advisor personalities (nice, funny, ironic)
-- **Multilingual Support**: Available in English and French
+- **AI Financial Assistant**: Chat interface for spending guidance and financial advice
+- **Impulse Purchase Analysis**: Long-term impact projections for purchases
+- **Investment Projections**: Compare spending vs. investing outcomes
+- **Personality Modes**: Choose between different advisor personalities (nice, funny, ironic)
+- **Multilingual**: English and French support
+- **Responsive Design**: Mobile and desktop optimized
 
-## Visual Overview
-
-![Chat Interface](img/chat_interface.png)
-*The intuitive chat interface.*
-
-![Dashboard in French](img/Dashboard%20inFrench.png)
-*Dashboard view in French, showcasing multilingual support.*
-
-![Mobile Responsive Dashboard](img/dasboard_mobile_responsive.png)
-*Mobile responsive design of the dashboard.*
-
-![Profile Settings](img/profil-setting.png)
-*User profile and personality settings.*
-
-## Getting Started
-
-### Prerequisites
-
-- Docker and Docker Compose (for production deployment)
-- Node.js 18+ and npm (for development)
-- Python 3.10+ (for development)
-- A valid Gemini API key from [Google AI Studio](https://ai.google.dev/)
-- lsof (required for checking open ports in deployment/development scripts)
-- A text editor such as nano or vi (used by the setup scripts)
-- Ensure you have proper Docker permissions (your user should be in the docker group or use sudo)
-
-### Quick Start
-
-For a quick start with all default settings, simply run:
+## Quick Start
 
 ```bash
-./start.sh
+./start.sh  # Production deployment with Docker
+./dev.sh    # Development setup
 ```
 
-This will set up and start the application in production mode.
-
-### Development Setup
-
-For local development:
-
-```bash
-./dev.sh
-```
-
-This script will guide you through setting up the development environment.
+Requires Docker/Docker Compose and a [Gemini API key](https://ai.google.dev/).
 
 ## Architecture
 
-MindfulWealth consists of two main components:
+**Backend**: Flask API with Google Gemini AI integration, user authentication, and financial data processing
 
-1. **Backend**: A Flask API that handles:
-   - User authentication
-   - Integration with Google's Gemini AI
-   - Financial data processing
-   - Database operations
+**Frontend**: React application with chat interface, dashboard, and settings management
 
-2. **Frontend**: A React application that provides:
-   - User interface for chat interactions
-   - Financial dashboard
-   - Settings management
-   - Responsive design for mobile and desktop
+**Deployment**: Dockerized with ports 80 (frontend), 3000 (alt frontend), 5000 (backend API)
 
-## Deployment
-
-For detailed deployment instructions, see [DEPLOYMENT.md](DEPLOYMENT.md).
-
-### Port Configuration
-
-The application uses the following ports by default:
-
-- **Port 80**: Main frontend access
-- **Port 3000**: Alternative frontend access
-- **Port 5000**: Backend API
-
-If any of these ports are already in use on your system, see the deployment guide for configuration options.
-
-## Chat Functionality
-
-For information about the chat functionality and recent fixes, see [CHAT_FIXES.md](CHAT_FIXES.md).
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## Acknowledgments
-
-- Google Gemini API for powering the AI assistant
-- Flask and React communities for their excellent frameworks
-- All contributors to this project
+*Screenshots and detailed setup instructions available in the [GitHub repository](https://github.com/tham-le/mindful).*

--- a/content/projects/miniRT.md
+++ b/content/projects/miniRT.md
@@ -39,104 +39,30 @@ stats:
 
 # miniRT - Ray Tracing Engine
 
-3D ray tracer built in C with multi-threading support for parallel rendering.
+A 3D ray tracer built in C with multi-threading support for parallel rendering. Renders photorealistic scenes by simulating light rays, supporting multiple geometric shapes, Phong lighting, shadows, and reflections.
 
-![C](https://img.shields.io/badge/C-00599C?style=for-the-badge&logo=c&logoColor=white)
+## Features
 
-## What I Built
-
-- **Ray Tracing Engine**: Renders 3D scenes by casting rays from camera through pixels
-- **Multi-Threading**: Added pthread support to render different image rows in parallel
-- **Multiple Shapes**: Spheres, planes, cylinders, cones, triangles
-- **Phong Lighting**: Ambient, diffuse, and specular lighting with shadows
-- **Reflections**: Recursive ray casting for reflective surfaces
-
-## Gallery
-
-Here are some examples of scenes rendered with miniRT:
-
-![Teapot](image/teapot.png)
-_A classic teapot scene._
-
-![Wolf](image/wolf.png)
-_A more complex model, showcasing triangle mesh rendering._
-
-![Cornell Box](image/cornell.png)
-_The Cornell Box, a standard test for ray tracers._
-
-![All Shapes](image/all-shapes.png)
-_A scene demonstrating all supported geometric primitives._
-
-![Candies](image/candies.png)
-_A colorful scene with multiple spheres and reflections._
-
-![Planet](image/planet.png)
-_A planetary scene with lighting and shadows._
-
-![Atom](image/atom.png)
-_An abstract representation of an atom._
-
-![Room Light](image/room-light.png)
-_A room scene with a bright light source._
-
-![Room Dark](image/room-dark.png)
-_The same room scene with a dimmer, more atmospheric lighting._
-
-![Dragon](image/dragon.png)
-_A majestic dragon, showcasing complex model rendering._
-
-## Installation
-
-### Prerequisites
-- GCC or Clang compiler
-- GNU Make
-- X11 development libraries (Linux)
-- MLX library
-
-### Build
-```bash
-git clone --recursive git@github.com:tham-le/miniRT.git
-cd miniRT
-make
-```
-
-## Technical Implementation
-
-```c
-// Multi-threaded rendering structure
-typedef struct s_thread_data {
-    t_data *data;
-    int    start_row;
-    int    end_row;
-    int    thread_id;
-} t_thread_data;
-
-// Optimized vector normalization
-void fast_normalize_vec(t_vector *vec) {
-    double mag_sq = vec_magnitude_squared(vec);
-    if (mag_sq == 0) return;
-    double inv_mag = 1.0 / sqrt(mag_sq);
-    scale_vec(vec, vec, inv_mag);
-}
-```
+- **Ray Tracing**: Casts rays from camera through pixels to render 3D scenes
+- **Multi-Threading**: Parallel rendering using pthreads for improved performance
+- **Shapes**: Spheres, planes, cylinders, cones, triangles (mesh support)
+- **Lighting**: Phong model with ambient, diffuse, specular components and shadows
+- **Reflections**: Recursive ray casting for realistic reflective surfaces
 
 ## Usage
 
 ```bash
+make
 ./miniRT scenes/one_sphere.rt
 ```
 
-## Scene Format
-```
-A  0.2        255,255,255    # Ambient lighting
-C  0,0,-5  0,0,1  70         # Camera
-L  -40,50,0  0.8  255,255,255 # Light
-sp 0,0,0   2      255,0,0    # Sphere
-```
+**Scene format**: Simple text-based format defining camera, lights, and objects with position, color, and material properties.
 
-## Skills Used
-- **C Programming** (8,000+ lines)
-- **Multi-threading** (pthreads) 
-- **3D Mathematics** (vectors, matrices, ray-object intersections)
-- **Graphics Programming** (ray tracing algorithms)
-- **Memory Management** (efficient data structures) 
+## Technical Stack
+
+- **Language**: C (8,000+ lines)
+- **Concurrency**: POSIX threads for workload distribution
+- **Mathematics**: 3D vector operations, ray-object intersections
+- **Graphics**: Ray tracing algorithms, Phong shading
+
+*Gallery of rendered scenes available in the [GitHub repository](https://github.com/tham-le/miniRT).* 


### PR DESCRIPTION
Streamlined content across About page and project descriptions to be more concise while maintaining essential information:

- About page: Condensed journey narrative and experience sections
- inception.md: Reduced from 145 to ~55 lines
- ft_irc.md: Reduced from 128 to ~63 lines
- miniRT.md: Reduced from 142 to ~68 lines
- fractol.md: Reduced from 125 to ~72 lines
- mindful.md: Reduced from 135 to ~62 lines
- Python-for-Data-Science.md: Reduced from 107 to ~53 lines

All detailed information remains accessible via GitHub repository links.