### PR TITLE
feat: Update portfolio navigation to link to notes.thamle.live subdomain

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -18,11 +18,11 @@ pagerSize = 12
 # Permalinks for different content types
 [permalinks]
 projects = "/projects/:slug/"
-notes = "/notes/:slug/"
+# notes = "/notes/:slug/"  # Disabled - notes now served from notes.thamle.live subdomain
 
 # Main sections for homepage
 [params]
-mainSections = ["projects", "ctf", "notes"]
+mainSections = ["projects", "ctf"]  # notes moved to notes.thamle.live subdomain
 featuredImageField = "image"
 rssFullContent = true
 favicon = "/favicon.ico"
@@ -94,8 +94,10 @@ weight = 40
 [[menu.main]]
 identifier = "notes"
 name = "Notes"
-url = "/notes/"
+url = "https://notes.thamle.live"
 weight = 50
+[menu.main.params]
+newTab = true
 
 [[menu.main]]
 identifier = "resume"


### PR DESCRIPTION
Changes to hugo.toml:
- Updated notes menu link from "/notes/" to "https://notes.thamle.live"
- Added newTab parameter to open notes in new tab (external link)
- Disabled notes permalink configuration (no longer serving notes via Hugo)
- Removed notes from mainSections (notes now external subdomain)

The notes link in the portfolio navigation will now point to the dedicated subdomain instead of the /notes/ subdirectory.