### PR TITLE
Fix portfolio website deployment issues

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy Hugo site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.128.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
+
+      - name: Install Node.js dependencies
+        run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+
+      - name: Generate CTF index files
+        run: |
+          bash scripts/generate-ctf-indexes.sh
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --gc \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/layouts/ctf/list.html
+++ b/layouts/ctf/list.html
@@ -24,12 +24,20 @@
         {{ if or (gt (len $sections) 0) (gt (len $pages) 0) }}
             <hr>
             {{/* Dynamically set the heading based on the page's depth */}}
-            {{ if eq (len .Ancestors) 2 }}
+            {{/*
+                Depth 0: /ctf/ - Show "CTF Events"
+                Depth 1: /ctf/EventName/ - Show "Categories"
+                Depth 2+: /ctf/EventName/Category/ - Show "Challenges"
+            */}}
+            {{ $depth := len .Ancestors }}
+            {{ if eq $depth 0 }}
+                <h2>CTF Events</h2>
+            {{ else if eq $depth 1 }}
                 <h2>Categories</h2>
             {{ else }}
                 <h2>Challenges</h2>
             {{ end }}
-            
+
             <section class="article-list--compact">
                 {{/* List sub-directories (like categories or challenge folders) */}}
                 {{ range $sections }}

--- a/scripts/generate-ctf-indexes.sh
+++ b/scripts/generate-ctf-indexes.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Generate _index.md files for CTF section from README.md files in the submodule
+# This script should be run before building the Hugo site
+
+set -e
+
+CTF_DIR="content/ctf"
+
+echo "Generating _index.md files for CTF section..."
+
+# Generate main CTF _index.md
+cat > "${CTF_DIR}/_index.md" << 'EOF'
+---
+title: "CTF Writeups"
+description: "Capture The Flag competition writeups and cybersecurity challenge solutions"
+layout: "list"
+---
+
+# CTF Writeups
+
+Collection of my Capture The Flag (CTF) competition writeups organized by event. Each writeup documents my approach to solving various cybersecurity challenges.
+EOF
+
+echo "Created ${CTF_DIR}/_index.md"
+
+# Generate _index.md for each CTF event directory
+for event_dir in "${CTF_DIR}"/*/; do
+  if [ -d "${event_dir}" ]; then
+    event_name=$(basename "${event_dir}")
+    readme_file="${event_dir}README.md"
+    index_file="${event_dir}_index.md"
+
+    if [ -f "${readme_file}" ]; then
+      echo "Processing ${event_name}..."
+
+      # Create _index.md with frontmatter and content from README
+      {
+        echo "---"
+        echo "title: \"${event_name}\""
+        echo "description: \"CTF Event: ${event_name}\""
+        echo "---"
+        echo ""
+        # Skip the first line (title) of README and include the rest
+        tail -n +2 "${readme_file}"
+      } > "${index_file}"
+
+      echo "  Created ${index_file}"
+
+      # Generate _index.md for category directories within this event
+      for cat_dir in "${event_dir}"*/; do
+        if [ -d "${cat_dir}" ]; then
+          cat_name=$(basename "${cat_dir}")
+          cat_index="${cat_dir}_index.md"
+
+          # Create simple _index.md for category
+          {
+            echo "---"
+            echo "title: \"${cat_name}\""
+            echo "---"
+          } > "${cat_index}"
+
+          echo "    Created ${cat_index}"
+        fi
+      done
+    fi
+  fi
+done
+
+echo "Done! Generated all _index.md files for CTF section."


### PR DESCRIPTION
This commit restructures the CTF writeups section to display content hierarchically:
- Main /ctf/ page: Lists all CTF events (IrisCTF, HeroCTF, etc.)
- Event pages (e.g., /ctf/IrisCTF/): Shows challenge categories
- Category pages (e.g., /ctf/IrisCTF/Cryptography/): Lists individual challenges

Changes:
- Updated layouts/ctf/list.html to properly handle page depth and display appropriate headings
- Added GitHub Actions workflow for automated deployment with Hugo
- Created script to generate _index.md files from submodule README.md files
- Script runs before Hugo build to ensure proper section recognition

This fixes the CTF section organization issue where challenges were not properly grouped by event.