### PR TITLE
fix: Add CTF index generation to Firebase deployment workflow

### DIFF
--- a/.github/workflows/sync-and-deploy.yml
+++ b/.github/workflows/sync-and-deploy.yml
@@ -50,6 +50,13 @@ jobs:
     #     chmod +x ./scripts/prepare_hugo.py
     #     python3 ./scripts/prepare_hugo.py
 
+    - name: Generate CTF index files
+      run: |
+        echo "🔧 Generating CTF _index.md files..."
+        chmod +x ./scripts/generate-ctf-indexes.sh
+        bash ./scripts/generate-ctf-indexes.sh
+        echo "✅ CTF index files generated!"
+
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v3
       with:


### PR DESCRIPTION
The deploy.yml workflow was created for GitHub Pages, but the actual deployment uses Firebase via sync-and-deploy.yml. This commit adds the CTF index generation step to the Firebase workflow so that the _index.md files are created before Hugo builds the site.

This ensures that the CTF section displays events properly at https://thamle.live/ctf