### PR TITLE
feat: Add event banner thumbnails to CTF event listings

### DIFF
--- a/scripts/generate-ctf-indexes.sh
+++ b/scripts/generate-ctf-indexes.sh
@@ -33,11 +33,16 @@ for event_dir in "${CTF_DIR}"/*/; do
     if [ -f "${readme_file}" ]; then
       echo "Processing ${event_name}..."
 
+      # Convert event name to lowercase and replace underscores with dashes for image path
+      image_slug=$(echo "${event_name}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+      image_path="/images/ctf/${image_slug}/event-banner.svg"
+
       # Create _index.md with frontmatter and content from README
       {
         echo "---"
         echo "title: \"${event_name}\""
         echo "description: \"CTF Event: ${event_name}\""
+        echo "image: \"${image_path}\""
         echo "---"
         echo ""
         # Skip the first line (title) of README and include the rest


### PR DESCRIPTION
Update the generate-ctf-indexes.sh script to include the 'image' frontmatter field for each CTF event's _index.md file. This displays the event-banner.svg thumbnails in the CTF events list.

The script now:
- Converts event names to lowercase
- Replaces underscores with dashes to match image directory names
- Adds image path: /images/ctf/{event-slug}/event-banner.svg

This makes the CTF events page more visually appealing with banner images for each event.